### PR TITLE
Updated credentials.pp and created carbon.pp.

### DIFF
--- a/manifests/carbon.pp
+++ b/manifests/carbon.pp
@@ -1,0 +1,9 @@
+class windows_services::carbon(
+    $carbondll   = "C:\\Carbon.dll",
+)
+{
+    file{"${carbondll}":
+        source => "puppet:///modules/windows_services/Carbon.dll",
+        source_permissions => ignore,
+    }
+}

--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -38,10 +38,7 @@ define windows_services::credentials(
     fail('servicename is mandatory')
   }
   validate_bool($delayed)
-  file{"${carbondll}":
-    source => "puppet:///modules/windows_services/Carbon.dll",
-    source_permissions => ignore,
-  }
+  require windows_services::carbon
   exec{"Change credentials - $servicename":
     command  => "\$username = '${username}';\$password = '${password}';\$privilege = \"SeServiceLogonRight\";[Reflection.Assembly]::LoadFile(\"${carbondll}\");[Carbon.LSA]::GrantPrivileges(\$username, \$privilege);\$serverName = \$env:COMPUTERNAME;\$service = '${servicename}';\$svcD=gwmi win32_service -computername \$serverName -filter \"name='\$service'\";\$StopStatus = \$svcD.StopService();\$ChangeStatus = \$svcD.change(\$null,\$null,\$null,\$null,\$null,\$null,\$username,\$password,\$null,\$null,\$null);\$startstatus = \$svcD.StartService();",
     provider => "powershell",


### PR DESCRIPTION
This is to address [Issue #2](https://github.com/insentia/windows_services/issues/2), where if multiple services are configured the catalog compilation fails due to the "carbon.dll" resource being declared twice.  Many thanks to @Areson for their help.